### PR TITLE
connectMiddleware component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react"
 import { connect } from "react-redux"
 import { Route, Switch, withRouter } from 'react-router-dom';
-
+import ConnectMiddleware from "./utils/connectMiddleware";
 import { Accueil } from "./components/accueil"
 import { Shotgun } from "./components/shotgun"
 import Tombola from "./components/tombola/container"
@@ -19,12 +19,14 @@ function AppComp(props) {
 
     return(
         <ApiStatus api={props.meta}>
+          <ConnectMiddleware authorizedPathnames={['/', '/accueil']}>
             <Switch className="fullWidth fullHeight">
                 <Route path="/shotgun" component={Shotgun} />
                 <Route path="/login" component={LoginComponent} />
                 <Route path="/tombola" component={Tombola}/>
                 <Route path="/" component={Accueil} />
             </Switch>
+          </ConnectMiddleware>
         </ApiStatus>
     )
 }

--- a/src/utils/connectMiddleware.jsx
+++ b/src/utils/connectMiddleware.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import * as c from "../skiutconstants";
+import PropTypes from "prop-types";
+
+const ConnectMiddleware = ({
+  history,
+  location,
+  user_auth,
+  authorizedPathnames,
+  children
+}) => {
+  const { pathname } = location;
+
+  React.useEffect(() => {
+    if( !authorizedPathnames.includes(pathname) && (!user_auth || !user_auth.auth ) && location.pathname !== '/login') {
+      history.push('/login');
+    }
+  }, [user_auth, pathname, authorizedPathnames]);
+
+  return children;
+}
+
+ConnectMiddleware.propTypes = {
+  history: PropTypes.any.isRequired,
+  location: PropTypes.object.isRequired,
+  user_auth: PropTypes.object,
+  authorizedPathnames: PropTypes.array,
+  children: PropTypes.node.isRequired,
+};
+
+ConnectMiddleware.defaultProps = {
+  user_auth: {},
+  authorizedPathnames: [],
+};
+
+const mapStateToProps = (state) => ({
+  user_auth: state[c.META]['data']['user'],
+});
+
+export default withRouter(connect(mapStateToProps)(ConnectMiddleware));


### PR DESCRIPTION
Ajout du connect middleware component qui redirige automatiquement sur la page de login si aucun user_auth n'est présent dans le state. 
il est possible de configurer des authorizedPathnames qui ne seront pas redirigés (par exemple la page d'accueil)